### PR TITLE
Update VirtualDisplay.lua

### DIFF
--- a/Scripts/Modules/VirtualDisplay.lua
+++ b/Scripts/Modules/VirtualDisplay.lua
@@ -344,7 +344,7 @@ function sm.scrapcomputers.virtualdisplay.new(displayWidth, displayHeight)
     local lastOffsetX = 0
     local lastOffsetY = 0
 
-    if sm.scrapcomputers.backend.cameraColorCache[displayID] then
+    if sm.scrapcomputers.backend.cameraColorCache and sm.scrapcomputers.backend.cameraColorCache[displayID] then
         sm.scrapcomputers.backend.cameraColorCache[displayID] = nil
     end
 


### PR DESCRIPTION
Add nil check to avoid crash.

Reproduce:

When creating multidisplays with any size displays, it raises nil access error.